### PR TITLE
Bugfix/endpoint and testing

### DIFF
--- a/app/Http/Middleware/RedirectStartPage.php
+++ b/app/Http/Middleware/RedirectStartPage.php
@@ -27,17 +27,25 @@ class RedirectStartPage
         // default settings
         // NOTE: required for backward compatibility
         //       admin and ccc run's on same port
-        $admin = env('HTTPS_ADMIN_PORT', '443');
-        $ccc   = env('HTTPS_CCC_PORT', '443');
+        $admin_port = env('HTTPS_ADMIN_PORT', '443');
+        $ccc_port   = env('HTTPS_CCC_PORT', '443');
 
         // if same port, show start page
-        if ($admin == $ccc)
+        if ($admin_port == $ccc_port)
             return $next($request);
 
-        if ($_SERVER['SERVER_PORT'] == $admin)
+		if (env('APP_ENV') == 'testing') {
+			// $_SERVER['SERVER_PORT'] does not exist if running phpunit
+			$server_port = \Request::getPort();
+		}
+		else {
+			$server_port = $_SERVER['SERVER_PORT'];
+		}
+
+        if ($server_port == $admin_port)
             return redirect('admin');
 
-        if ($_SERVER['SERVER_PORT'] == $ccc)
+        if ($server_port == $ccc_port)
             return redirect('customer');
 
         // start page

--- a/modules/ProvBase/Database/Seeders/EndpointTableSeeder.php
+++ b/modules/ProvBase/Database/Seeders/EndpointTableSeeder.php
@@ -3,6 +3,7 @@
 namespace Modules\ProvBase\Database\Seeders;
 
 use Modules\ProvBase\Entities\Endpoint;
+use Modules\ProvBase\Entities\Modem;
 
 class EndpointTableSeeder extends \BaseSeeder {
 
@@ -36,11 +37,22 @@ class EndpointTableSeeder extends \BaseSeeder {
 				$modem_id = null;
 		}
 
+		if (rand(0, 1) == 1) {
+			$fixed_ip = 1;
+			$ip = $faker->localIpv4();
+		}
+		else {
+			$fixed_ip = 0;
+			$ip = null;
+		}
+
 		$ret = [
 			'mac' => $faker->macAddress(),
 			'description' => $faker->realText(200),
-			'hostname' => "$faker->domainWord.$faker->domainName",
+			'hostname' => $faker->domainWord.$faker->domainWord.$faker->domainWord,
 			'modem_id' => $modem_id,
+			'fixed_ip' => $fixed_ip,
+			'ip' => $ip,
 		];
 
 		return $ret;

--- a/modules/ProvBase/Entities/Endpoint.php
+++ b/modules/ProvBase/Entities/Endpoint.php
@@ -16,7 +16,7 @@ class Endpoint extends \BaseModel {
 		return array(
 			'mac' => 'required|mac|unique:endpoint,mac,'.$id.',id,deleted_at,NULL',
 			'hostname' => 'regex:/^[0-9A-Za-z\-]+$/|required|unique:endpoint,hostname,'.$id.',id,deleted_at,NULL',
-			'ip' => 'ip|unique:endpoint,ip,'.$id.',id,deleted_at,NULL',
+			'ip' => 'required|ip|unique:endpoint,ip,'.$id.',id,deleted_at,NULL',
 		);
 	}
 
@@ -150,6 +150,14 @@ class Endpoint extends \BaseModel {
 
 class EndpointObserver {
 
+
+	public function creating($endpoint)
+	{
+		if (!$endpoint->fixed_ip) {
+			$endpoint->ip = null;
+		}
+	}
+
 	public function created($endpoint)
 	{
 		$endpoint->make_dhcp();
@@ -159,6 +167,9 @@ class EndpointObserver {
 
 	public function updating($endpoint)
 	{
+		if (!$endpoint->fixed_ip) {
+			$endpoint->ip = null;
+		}
 		$endpoint->nsupdate(true);
 	}
 

--- a/modules/ProvBase/Entities/Modem.php
+++ b/modules/ProvBase/Entities/Modem.php
@@ -462,7 +462,7 @@ class Modem extends \BaseModel {
 		$max_cpe = $cpe_cnt ? : 2; 		// default 2
 		$network_access = 1;
 
-		if (count($this->mtas))
+		if (\PPModule::is_active('provvoip') && (count($this->mtas)))
 			$max_cpe = count($this->mtas) + (($this->contract->telephony_only || !$this->network_access) ? 0 : $max_cpe);
 		else if (!$this->network_access)
 			$network_access = 0;
@@ -475,8 +475,10 @@ class Modem extends \BaseModel {
 		// make text and write to file
 		$conf = "\tNetworkAccess $network_access;\n";
 		$conf .= "\tMaxCPE $max_cpe;\n";
-		foreach ($this->mtas as $mta)
-			$conf .= "\tCpeMacAddress $mta->mac;\n";
+		if (\PPModule::is_active('ProvVoip')) {
+			foreach ($this->mtas as $mta)
+				$conf .= "\tCpeMacAddress $mta->mac;\n";
+		}
 
 		$text = "Main\n{\n".$conf.$cf->text_make($modem, "modem")."\n}";
 

--- a/modules/ProvBase/Http/Controllers/EndpointController.php
+++ b/modules/ProvBase/Http/Controllers/EndpointController.php
@@ -33,8 +33,9 @@ class EndpointController extends \BaseController {
 
 	function prepare_rules($rules, $data)
 	{
-		if ($data['fixed_ip'] == '1')
-			$rules['ip'] .= '|required';
+		// as we are setting IP to “null” if no fixed IP is used: remove rule in this case
+		if ($data['fixed_ip'] == '0')
+			$rules['ip'] = '';
 
 		return $rules;
 	}

--- a/modules/ProvVoip/module.json
+++ b/modules/ProvVoip/module.json
@@ -3,15 +3,11 @@
     "alias": "provvoip",
     "description": "VOIP",
     "icon": "fa-phone",
-    "keywords": [
-
-    ],
+    "keywords": [],
     "active": 1,
     "order": 21,
     "priority": 0,
-    "providers": [
-
-    ],
+    "providers": [],
     "files": [
         "start.php"
     ]

--- a/nmsprime_testsuite.php
+++ b/nmsprime_testsuite.php
@@ -7,6 +7,9 @@
  *
  * Within there are circuits defined – e.g. to enable/disable modules.
  *
+ * Tests should be run with a freshly migrated and seeded database to prevent
+ * side effects.
+ *
  * @author Patrick Reichel
  */
 class UnitTestStarter {
@@ -24,8 +27,8 @@ class UnitTestStarter {
 	// each circuits holds an array with modules to disable
 	protected $circuits = [
 		'all_modules_enabled' => [],
-		/* 'no_voip' => ['Provvoip', 'Provvoipenvia', 'Voipmon'], */
-		/* 'no_envia' => ['Provvoipenvia'], */
+		'no_envia' => ['Provvoipenvia'],
+		'no_voip' => ['Provvoip', 'Provvoipenvia', 'Voipmon'],
 	];
 
 

--- a/tests/RoutesAuthTest.php
+++ b/tests/RoutesAuthTest.php
@@ -31,6 +31,7 @@ class RoutesAuthTest extends TestCase {
 		'Auth.login',
 		'CustomerAuth.login',
 		'CHome',
+		'Home',
 	];
 
 


### PR DESCRIPTION
The Endpoint stuff crashed the unit testing (mainly the seeder) – fixed it.

I introduced new behavior: If fixed_ip is not checked then IP in database is set to null (EndpointObserver methods creating() and updating()). Otherwise this IP will silently be blocked from reuse.
@olebowle Are you with me on this change? Or is there a need to keep an IP address bundled with an endpoint?