### PR TITLE
Directory /config dir not longer in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /bootstrap/compiled.php
 /vendor
-/config
 composer.phar
 composer.lock
 /node_modules
@@ -49,7 +48,7 @@ Documentation/doxywarn.log
 # ignore queue process pid's
 *queue.pid
 
-# ignore debug output from testing 
+# ignore debug output from testing
 phpunit/*.htm
 
 # ignore xml files created from template

--- a/config/README
+++ b/config/README
@@ -1,0 +1,3 @@
+Do not hardcode any configuration in this directory – changes will be overwritten!
+
+Instead use *.env files in /etc/nmsprime/env for your installation.


### PR DESCRIPTION
As all configuration is done in /etc/nmsprime/env/*.env now there should
not exist hardcoded entries here.
IMO it should be save to make this directory part of the repo, again.