### PR TITLE
Hidden form field “type” in MtaController lead to empty type in DB.

### DIFF
--- a/modules/ProvVoip/Http/Controllers/MtaController.php
+++ b/modules/ProvVoip/Http/Controllers/MtaController.php
@@ -27,7 +27,10 @@ class MtaController extends \BaseController {
 			array('form_type' => 'text', 'name' => 'hostname', 'description' => 'Hostname', 'options' => ['readonly']),
 			array('form_type' => 'text', 'name' => 'modem_id', 'description' => 'Modem', 'hidden' => 1),
 			array('form_type' => 'select', 'name' => 'configfile_id', 'description' => 'Configfile', 'value' => $this->_add_empty_first_element_to_options($model->html_list($model->configfiles(), 'name'))),
-			array('form_type' => 'select', 'name' => 'type', 'description' => 'Type', 'value' => Mta::getPossibleEnumValues('type', false), 'hidden' => 1),
+
+			// ATM there is only SIP
+			/* array('form_type' => 'select', 'name' => 'type', 'description' => 'Type', 'value' => Mta::getPossibleEnumValues('type', false)), */
+			array('form_type' => 'select', 'name' => 'type', 'description' => 'Type', 'value' => 'sip', 'hidden' => 1),
 		);
 	}
 


### PR DESCRIPTION
Fixed at live instance, too.