### PR TITLE
Migration for renaming dhcpd running on fresh install.

### DIFF
--- a/modules/ProvBase/Database/Migrations/2018_06_25_000100_install_dhcpd_rename.php
+++ b/modules/ProvBase/Database/Migrations/2018_06_25_000100_install_dhcpd_rename.php
@@ -34,12 +34,21 @@ class InstallDhcpdRename extends BaseMigration {
 			system("sed -i 's|dhcp/nmsprime|dhcp-nmsprime|' $new/dhcpd.conf");
 		}
 
+		system("chown -R apache:dhcpd $new");
+
 		// remove old folder
 		exec("rm -rf $old");
 
 		// regenerate config files in new folder
-		\Artisan::call('nms:dhcp');
-		system("chown -R apache:dhcpd $new");
+        // check if artisan command can safely be called – in case of a fresh installation with enabled
+        // ProvVoip there does not exist a mta table ATM (will be migrated later)
+        if (
+            (!\Module::collections()->has('ProvVoip'))
+            ||
+            (Schema::hasTable('mta'))
+        ) {
+            \Artisan::call('nms:dhcp');
+        }
 
 		// reload systemd because path-dhcpd.conf was changed
 		system('systemctl daemon-reload');


### PR DESCRIPTION
At an installation from git the dhcp artisan can not be run at ProvBase
migration time – there is no mta table which causes an exeption in
building the DHCP config file for MTAs.