### PR TITLE
Bugfix: Custom Abilities were falsely granted

### DIFF
--- a/resources/views/auth/abilities.blade.php
+++ b/resources/views/auth/abilities.blade.php
@@ -343,26 +343,22 @@ new Vue({
         if (this.$refs['allowed'+ id][0].checked) {
             if (id == this.allowAllId) {
                 this.allowAll = true;
+                this.allowViewAll = undefined;
                 this.$refs['allowed'+ this.allowViewAllId][0].checked = false;
                 this.changed.splice(this.allowViewAllId, 1, this.hasChanged(this.allowViewAllId));
-                this.allowViewAll = undefined;
+                delete this.roleAbilities[this.allowViewAllId];
             }
 
-            if (id == this.allowViewAllId)
-                this.allowViewAll = true;
-
+            this.allowViewAll =  id == this.allowViewAllId ? true : this.allowViewAll;
             this.roleAbilities[id] = this.customAbilities[id]['localTitle'];
             delete this.roleForbiddenAbilities[id];
         } else {
-
             if (id == this.allowAllId) {
                 this.allowAll = undefined;
                 this.changed.splice(this.allowViewAllId, 1, this.hasChanged(this.allowViewAllId));
             }
 
-            if (id == this.allowViewAllId)
-                this.allowViewAll = undefined;
-
+            this.allowViewAll =  id == this.allowViewAllId ? undefined : this.allowViewAll;
             delete this.roleAbilities[id];
         }
 
@@ -372,11 +368,9 @@ new Vue({
     },
     customForbid : function (id) {
         if (this.$refs['forbidden'+ id][0].checked) {
-            if (id == this.allowAllId) this.allowAll = false;
             this.roleForbiddenAbilities[id] = this.customAbilities[id]['localTitle'];
             delete this.roleAbilities[id];
         } else {
-            if (id == this.allowAllId) this.allowAll = undefined;
             delete this.roleForbiddenAbilities[id];
         }
 


### PR DESCRIPTION
Found a critical Bug, where in rare occasions, when clicking a lot of custom Abilities without actually submitting, after a save, false abilities were granted...
This PR fixes this, as all undefined array members get "filtered" away.