### PR TITLE
BugFix: User Language Setting

### DIFF
--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -68,21 +68,6 @@ class BaseController extends Controller
      */
     protected $file_upload_paths = [];
 
-    /**
-     * Constructor
-     *
-     * Basically this is a placeholder for eventually later use. I need to
-     * overwrite the constructor in a subclass – and want to call the parent
-     * constructor if there are changes in base classes. But calling the
-     * parent con is only possible if it is explicitely defined…
-     *
-     * @author Patrick Reichel
-     */
-    public function __construct()
-    {
-        // place your code here
-    }
-
     /*
      * Base Function for Breadcrumb. -> Panel Header Right
      * overwrite this function in child controller if required.

--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -80,8 +80,7 @@ class BaseController extends Controller
      */
     public function __construct()
     {
-        // set language
-        App::setLocale(BaseViewController::get_user_lang());
+        // place your code here
     }
 
     /*

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\SetLanguage::class,
         ],
         'api' => [
             'throttle:60,1',

--- a/app/Http/Middleware/SetLanguage.php
+++ b/app/Http/Middleware/SetLanguage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App;
+use Closure;
+use App\Http\Controllers\BaseViewController;
+
+class SetLanguage
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        App::setLocale(BaseViewController::get_user_lang());
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Fix the language setting.
Language is now set through middleware instead of Basecontrollers constructor.
Reason for this is, that auth() user is not available when Basecontroller is booting.