### PR TITLE
Fix duplicate names and error during import of configfiles

### DIFF
--- a/app/BaseModel.php
+++ b/app/BaseModel.php
@@ -213,7 +213,7 @@ class BaseModel extends Eloquent
             // the calling method's name and use that as the relationship name as most
             // of the time this will be what we desire to use for the relationships.
             if (is_null($relation)) {
-                list($current, $caller) = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+                [$current, $caller] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
                 $relation = $caller['function'];
             }

--- a/modules/ProvBase/Http/Controllers/ConfigfileController.php
+++ b/modules/ProvBase/Http/Controllers/ConfigfileController.php
@@ -156,9 +156,11 @@ class ConfigfileController extends \BaseController
     public function recreateTree($content, $hasName)
     {
         // see if this name already exists
-        while (\Modules\Provbase\Entities\Configfile::where('name', '=', $content['name'])->count() > 0) {
-            $content['name'] .= '(2)';
+        $originalConfigfiles=Configfile::all()->pluck('name');
+        while($originalConfigfiles->contains($content['name'])) {
+            $content['name'].='(2)';
         }
+        $originalConfigfiles->push($content['name']);
 
         // if there are no children
         if (! array_key_exists('children', $content)) {

--- a/modules/ProvBase/Http/Controllers/ConfigfileController.php
+++ b/modules/ProvBase/Http/Controllers/ConfigfileController.php
@@ -112,7 +112,7 @@ class ConfigfileController extends \BaseController
             return trans('messages.invalidJson');
         }
 
-        $this->recreateTree($json, Input::get()['name'] == '' ? true : false);
+        $this->recreateTree($json, Input::get()['name'] == '' ? true : false, Configfile::all()->pluck('name'));
     }
 
     /**
@@ -153,10 +153,9 @@ class ConfigfileController extends \BaseController
      * @param array $content
      * @param bool $hasName
      */
-    public function recreateTree($content, $hasName)
+    public function recreateTree($content, $hasName, $originalConfigfiles)
     {
         // see if this name already exists
-        $originalConfigfiles = Configfile::all()->pluck('name');
         while ($originalConfigfiles->contains($content['name'])) {
             $content['name'] .= '(2)';
         }
@@ -187,7 +186,7 @@ class ConfigfileController extends \BaseController
         // recursively for all children
         foreach ($children as $group) {
             foreach ($group as $child) {
-                $this->recreateTree($child, false);
+                $this->recreateTree($child, false, $originalConfigfiles);
             }
         }
     }

--- a/modules/ProvBase/Http/Controllers/ConfigfileController.php
+++ b/modules/ProvBase/Http/Controllers/ConfigfileController.php
@@ -155,6 +155,12 @@ class ConfigfileController extends \BaseController
      */
     public function recreateTree($content, $hasName)
     {
+        // see if this name already exists
+        while(\Modules\Provbase\Entities\Configfile::where('name', '=', $content['name'])->count() > 0)
+        {
+          $content['name'].='(2)';
+        }
+
         // if there are no children
         if (! array_key_exists('children', $content)) {
             $this->checkAndSetContent($content, $hasName);

--- a/modules/ProvBase/Http/Controllers/ConfigfileController.php
+++ b/modules/ProvBase/Http/Controllers/ConfigfileController.php
@@ -156,9 +156,8 @@ class ConfigfileController extends \BaseController
     public function recreateTree($content, $hasName)
     {
         // see if this name already exists
-        while(\Modules\Provbase\Entities\Configfile::where('name', '=', $content['name'])->count() > 0)
-        {
-          $content['name'].='(2)';
+        while (\Modules\Provbase\Entities\Configfile::where('name', '=', $content['name'])->count() > 0) {
+            $content['name'] .= '(2)';
         }
 
         // if there are no children

--- a/modules/ProvBase/Http/Controllers/ModemController.php
+++ b/modules/ProvBase/Http/Controllers/ModemController.php
@@ -47,7 +47,7 @@ class ModemController extends \BaseController
 
         $pos = explode(',', \Input::get('pos'));
         if (count($pos) == 2) {
-            list($model['x'], $model['y']) = $pos;
+            [$model['x'], $model['y']] = $pos;
         }
 
         $installation_address_change_date_options = ['placeholder' => 'YYYY-MM-DD'];


### PR DESCRIPTION
Adds "(2)" to the name of a configfile if this name already exists during import
