### PR TITLE
Bugfix:  Fix backslash display issue in datatables

### DIFF
--- a/resources/views/Generic/index.blade.php
+++ b/resources/views/Generic/index.blade.php
@@ -141,6 +141,7 @@ $(document).ready(function() {
         autoWidth: false, {{-- Option to ajust Table to Width of container --}}
         dom: 'lBfrtip', {{-- sets order and what to show  --}}
         stateSave: true, {{-- Save Search Filters and visible Columns --}}
+        stateDuration: 60 * 60 * 24, {{-- Time the State is used - set to 24h --}}
         lengthMenu:  [ [10, 25, 100, 250, 500, -1], [10, 25, 100, 250, 500, "{{ trans('view.jQuery_All') }}" ] ], {{-- Filter to List # Datasets --}}
         {{-- Responsive Column --}}
         columnDefs: [],

--- a/resources/views/datatables/colsearch.blade.php
+++ b/resources/views/datatables/colsearch.blade.php
@@ -8,7 +8,7 @@ initComplete: function () {
         if ($(this.footer()).hasClass('searchable')){
             $(input).appendTo($(column.footer()).empty())
             .on('keyup', function () {
-                var val = $.fn.dataTable.util.escapeRegex($(this).val());
+                var val = $(this).val();
 
                 column.search(val ? val : '', true, false).draw();
             });
@@ -18,7 +18,7 @@ initComplete: function () {
     var state = this.api().state.loaded();
     if (state) {
         this.api().columns().eq(0).each(function (colIdx) {
-            var colSearch = state.columns[colIdx].search.search.replace(/\\/g, "");
+            var colSearch = state.columns[colIdx].search.search;
             if (colSearch.search) {
                 $('input', this.column(colIdx).footer()).val(colSearch);
             }

--- a/resources/views/datatables/colsearch.blade.php
+++ b/resources/views/datatables/colsearch.blade.php
@@ -18,9 +18,9 @@ initComplete: function () {
     var state = this.api().state.loaded();
     if (state) {
         this.api().columns().eq(0).each(function (colIdx) {
-            var colSearch = state.columns[colIdx].search;
+            var colSearch = state.columns[colIdx].search.search.replace(/\\/g, "");
             if (colSearch.search) {
-                $('input', this.column(colIdx).footer()).val(colSearch.search);
+                $('input', this.column(colIdx).footer()).val(colSearch);
             }
         });
     }


### PR DESCRIPTION
@Gitrosa found this Bug: when searching for special Characaters a Slash was added, when the search values got pulled from local storage.

This PR, consisting of only one commit, should fix this issue.
It removes backslashes for search data coming from local Storage with a RegEx. 
