### PR TITLE
Dunning and Property Management Database Fixes

### DIFF
--- a/modules/Dunning/Database/Migrations/2019_04_16_001000_create_Debt_table.php
+++ b/modules/Dunning/Database/Migrations/2019_04_16_001000_create_Debt_table.php
@@ -28,6 +28,10 @@ class CreateDebtTable extends BaseMigration
             $table->float('total_fee', 10, 4);
             $table->string('description')->nullable();
 
+            $table->foreign('contract_id')->references('id')->on('contract')->onDelete('cascade')->onUpdate('cascade');
+            $table->foreign('invoice_id')->references('id')->on('invoice')->onDelete('set null')->onUpdate('cascade');
+            $table->foreign('sepamandate_id')->references('id')->on('sepamandate')->onDelete('set null')->onUpdate('cascade');
+
             return parent::up();
         });
     }

--- a/modules/PropertyManagement/Database/Migrations/2019_07_22_000100_create_Node_table.php
+++ b/modules/PropertyManagement/Database/Migrations/2019_07_22_000100_create_Node_table.php
@@ -17,7 +17,7 @@ class CreateNodeTable extends BaseMigration
             $this->up_table_generic($table);
 
             $table->unsignedInteger('netelement_id')->nullable();
-            $table->foreign('netelement_id')->references('id')->on('netelement');
+            $table->foreign('netelement_id')->references('id')->on('netelement')->onDelete('set null')->onUpdate('cascade');
 
             $table->string('name');
             $table->string('street');

--- a/modules/PropertyManagement/Database/Migrations/2019_07_22_000400_create_Realty_table.php
+++ b/modules/PropertyManagement/Database/Migrations/2019_07_22_000400_create_Realty_table.php
@@ -17,7 +17,7 @@ class CreateRealtyTable extends BaseMigration
             $this->up_table_generic($table);
 
             $table->unsignedInteger('node_id');
-            $table->foreign('node_id')->references('id')->on('node');
+            $table->foreign('node_id')->references('id')->on('node')->onDelete('cascade')->onUpdate('cascade');
 
             $table->string('name')->nullable();
             $table->string('number')->nullable();

--- a/modules/PropertyManagement/Database/Migrations/2019_07_23_000100_create_Apartment_table.php
+++ b/modules/PropertyManagement/Database/Migrations/2019_07_23_000100_create_Apartment_table.php
@@ -17,7 +17,7 @@ class CreateApartmentTable extends BaseMigration
             $this->up_table_generic($table);
 
             $table->unsignedInteger('realty_id');
-            $table->foreign('realty_id')->references('id')->on('realty');
+            $table->foreign('realty_id')->references('id')->on('realty')->onDelete('cascade')->onUpdate('cascade');
 
             // $table->string('name')->nullable();
             $table->string('number')->nullable();

--- a/modules/PropertyManagement/Database/Migrations/2019_07_24_000100_update_ContractAddPropertyManagementRelations.php
+++ b/modules/PropertyManagement/Database/Migrations/2019_07_24_000100_update_ContractAddPropertyManagementRelations.php
@@ -17,8 +17,8 @@ class UpdateContractAddPropertyManagementRelations extends BaseMigration
             $table->unsignedInteger('realty_id')->nullable();
             $table->unsignedInteger('apartment_id')->nullable();
 
-            $table->foreign('realty_id')->references('id')->on('realty');
-            $table->foreign('apartment_id')->references('id')->on('apartment');
+            $table->foreign('realty_id')->references('id')->on('realty')->onDelete('set null')->onUpdate('cascade');
+            $table->foreign('apartment_id')->references('id')->on('apartment')->onDelete('set null')->onUpdate('cascade');
         });
     }
 


### PR DESCRIPTION
There are more Constraints to set, to secure integrity on DB level.

This ensures that e.g., when a contract is deleted all related objects get deleted too (cascade) or that (for "nullable relations" the key is set to null.
