### PR TITLE
Bugfix/set empty strings to null

### DIFF
--- a/database/migrations/2019_07_01_163135_set_empty_strings_to_null.php
+++ b/database/migrations/2019_07_01_163135_set_empty_strings_to_null.php
@@ -74,6 +74,8 @@ class SetEmptyStringsToNull extends Migration
                 $nullable[$field] = empty(array_intersect($required, explode('|', $rule))) ? true : false;
             }
 
+            dump("Set empty strings to null in {$tableName} table.");
+
             // get all column names
             $tableColumns = $this->getTableColumns($tableName);
             foreach (DB::getSchemaBuilder()->getColumnListing($tableName) as $column) {

--- a/database/migrations/2019_07_01_163135_set_empty_strings_to_null.php
+++ b/database/migrations/2019_07_01_163135_set_empty_strings_to_null.php
@@ -87,7 +87,11 @@ class SetEmptyStringsToNull extends Migration
                 $type = DB::connection()->getDoctrineColumn($tableName, $column)->getType()->getName();
 
                 // exceptions: id, booleans and foreign keys
-                if ($column === 'id' || $type === 'boolean' || ($type == 'integer' && Str::endsWith($column, '_id'))) {
+                if (
+                    $column === 'id' ||
+                    $type === 'boolean' ||
+                    ($column !== 'parent_id' && $type == 'integer' && Str::endsWith($column, '_id'))
+                ) {
                     continue;
                 }
 


### PR DESCRIPTION
this fixes the bug that parent_ids was skipped as it ends on "_id"

Furthermore this adds some Logging to the console as
"Set empty strings to null for [table] table"

