### PR TITLE
Feature/small fixes christian

### DIFF
--- a/modules/ProvBase/Database/Migrations/2020_01_07_094323_add_configfile_id_to_index.php
+++ b/modules/ProvBase/Database/Migrations/2020_01_07_094323_add_configfile_id_to_index.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddConfigfileIdToIndex extends \BaseMigration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('modem', function (Blueprint $table) {
+            $table->index('configfile_id');
+        });
+
+        Schema::table('mta', function (Blueprint $table) {
+            $table->index('configfile_id');
+        });
+
+        Schema::table('configfile', function (Blueprint $table) {
+            $table->index('parent_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('modem', function (Blueprint $table) {
+            $table->dropIndex(['configfile_id']);
+        });
+
+        Schema::table('mta', function (Blueprint $table) {
+            $table->dropIndex(['configfile_id']);
+        });
+
+        Schema::table('configfile', function (Blueprint $table) {
+            $table->dropIndex(['parent_id']);
+        });
+    }
+}

--- a/modules/ProvBase/Entities/Configfile.php
+++ b/modules/ProvBase/Entities/Configfile.php
@@ -431,10 +431,10 @@ class Configfile extends \BaseModel
     public static function undeletables()
     {
         $used_ids = [];
+
         // only public configfiles can be assigned to a modem or mta
-        foreach (self::where('public', '=', 'yes')->get() as $cf) {
-            if ((($cf->device == 'cm') && $cf->modem()->count()) ||
-                (($cf->device == 'mta') && $cf->mtas()->count())) {
+        foreach (self::where('public', 'yes')->withCount('modem', 'mtas')->with('parent')->get() as $cf) {
+            if ((($cf->device == 'cm') && $cf->modem_count) || (($cf->device == 'mta') && $cf->mtas_count)) {
                 array_push($used_ids, $cf->id);
                 self::_add_parent($used_ids, $cf);
             }


### PR DESCRIPTION
* Fix Query for configfile tree view as it takes very long
  This shortens page load on my VM by factor of 2 (4s to under 2s) and reduces the db calls (130 to 32)
  The indexing brings just a small speed boost in page load, but queries are executed much faster (i.e. 250ms to 40 ms), so other pages could also benefit from this change