### PR TITLE
ERD performance

### DIFF
--- a/app/BaseModel.php
+++ b/app/BaseModel.php
@@ -26,8 +26,6 @@ class BaseModel extends Eloquent
     // flag showing if children also shall be deleted on Model::delete()
     protected $delete_children = true;
 
-    public $external_voip_enabled;
-    public $billing_enabled;
     protected $fillable = [];
 
     public $observer_enabled = true;
@@ -42,36 +40,6 @@ class BaseModel extends Eloquent
 
     // Add Comment here. ..
     protected $guarded = ['id'];
-
-    /**
-     * Constructor.
-     * Used to set some helper variables.
-     *
-     * @author Patrick Reichel
-     *
-     * @param $attributes pass through to Eloquent contstructor.
-     */
-    public function __construct($attributes = [])
-    {
-        // Config Host Setup
-        // @note: This could be used to fetch configuration tables
-        //        (like configfiles) from a global NMS Prime system
-        // @author: Torsten Schmidt
-        $env = env('DB_CONFIG_TABLES', false);
-
-        if ($env && strpos($env, $this->table) !== false) {
-            $this->connection = 'mysql-config';
-            \Log::debug('Use mysql-config connection to access '.$this->table.' table');
-        }
-
-        // call Eloquent constructor
-        // $attributes are needed! (or e.g. seeding and creating will not work)
-        parent::__construct($attributes);
-
-        // set helper variables
-        $this->external_voip_enabled = $this->external_voip_enabled();
-        $this->billing_enabled = $this->billing_enabled();
-    }
 
     /**
      * Helper to get the model name.
@@ -95,9 +63,8 @@ class BaseModel extends Eloquent
 
         $model_name = static::class;
 
-        // App\Auth is booted during authentication and doesnt need/have an observe method
         // GuiLog has to be excluded to prevent an infinite loop log entry creation
-        if ($model_name == 'App\Auth' || $model_name == 'App\GuiLog') {
+        if ($model_name == GuiLog::class) {
             return;
         }
 
@@ -290,57 +257,6 @@ class BaseModel extends Eloquent
     public function view_has_one()
     {
         return [];
-    }
-
-    /**
-     * Check if VoIP is enabled.
-     *
-     * TODO: - move to Contract/ContractController or use directly,
-     *         ore use fucntion directly instead of helpers variable
-     *
-     * @author Patrick Reichel
-     *
-     * @return true if one of the VoIP modules is enabled (currently only ProvVoipEnvia), else false
-     */
-    public function external_voip_enabled()
-    {
-        $voip_modules = [
-            'ProvVoipEnvia',
-        ];
-
-        foreach ($voip_modules as $module) {
-            if (\Module::collections()->has($module)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if billing is enabled.
-     *
-     * TODO: - currently this is a dummy (= we don't have a billing module yet!!)
-     *       - move to Contract/ContractController or use directly,
-     *         ore use fucntion directly instead of helpers variable
-     *
-     * @author Patrick Reichel
-     *
-     * @return true if one of the billing modules is enabled, else false
-     */
-    public function billing_enabled()
-    {
-        $billing_modules = [
-            'BillingBase',
-        ];
-
-        foreach ($billing_modules as $module) {
-            if (\Module::collections()->has($module)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -376,7 +376,7 @@ class BaseController extends Controller
         if (! isset($a['networks'])) {
             $a['networks'] = [];
             if (\Module::collections()->has('HfcReq') && Bouncer::can('view', \Modules\HfcBase\Entities\TreeErd::class)) {
-                $a['networks'] = \Modules\HfcReq\Entities\NetElement::get_all_net();
+                $a['networks'] = \Modules\HfcReq\Entities\NetElement::getNetsWithClusters();
             }
         }
 

--- a/modules/HfcBase/Http/Controllers/HfcBaseController.php
+++ b/modules/HfcBase/Http/Controllers/HfcBaseController.php
@@ -9,9 +9,6 @@ use Modules\HfcBase\Entities\IcingaObject;
 
 class HfcBaseController extends BaseController
 {
-    // The Html Link Target
-    protected $html_target = '';
-
     public function index()
     {
         $title = 'Hfc Dashboard';

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -275,7 +275,7 @@ class TreeErdController extends HfcBaseController
                     $cri = $netelem->modems_critical_count;
                     $avg = $netelem->modemsUsPwrAvg;
 
-                    $file .= "\n node [label = \"$numa\\n$num/$cri\\n$avg\", shape = circle, style = filled, color=$color, URL=\"$url\", target=\"".$this->html_target.'"];';
+                    $file .= "\n node [label = \"$numa\\n$num/$cri\\n$avg\", shape = circle, style = filled, color=$color, URL=\"$url\", target=\"\"];";
                     $file .= " \"C$idtree\"";
                     $file .= "\n \"$id\" -> C$idtree [color = green]";
                 }

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -194,9 +194,9 @@ class TreeErdController extends HfcBaseController
         $n = 0;
         $p1 = '';
 
-        $netelements = $query->where('id', '>', '2')->with('netelementtype', 'parent')->orderBy('pos')->get();
+        $netelements = NetElement::withActiveModems()->get();
 
-        if (! $netelements->count()) {
+        if (! $netelements->first()) {
             return;
         }
 
@@ -292,13 +292,13 @@ class TreeErdController extends HfcBaseController
                 $url = \BaseRoute::get_base_url()."/Customer/netelement_id/$idtree";
                 $n++;
 
-                $state = ModemHelper::ms_state($idtree);
+                $state = ModemHelper::ms_state($netelem);
                 if ($state != -1) {
                     $color = ModemHelper::ms_state_to_color($state);
-                    $num = ModemHelper::ms_num($idtree);
-                    $numa = ModemHelper::ms_num_all($idtree);
-                    $cri = ModemHelper::ms_cri($idtree);
-                    $avg = ModemHelper::ms_avg($idtree);
+                    $num = $netelem->ms_num;
+                    $numa = $netelem->modems_count;
+                    $cri = $netelem->ms_cri;
+                    $avg = $netelem->msAvg;
 
                     $file .= "\n node [label = \"$numa\\n$num/$cri\\n$avg\", shape = circle, style = filled, color=$color, URL=\"$url\", target=\"".$this->html_target.'"];';
                     $file .= " \"C$idtree\"";

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -304,8 +304,8 @@ class TreeErdController extends HfcBaseController
                     $color = ModemHelper::ms_state_to_color($state);
                     $num = $netelem->ms_num;
                     $numa = $netelem->modems_count;
-                    $cri = $netelem->ms_cri;
-                    $avg = $netelem->msAvg;
+                    $cri = $netelem->modems_critical_count;
+                    $avg = $netelem->modemsUsPwrAvg;
 
                     $file .= "\n node [label = \"$numa\\n$num/$cri\\n$avg\", shape = circle, style = filled, color=$color, URL=\"$url\", target=\"".$this->html_target.'"];';
                     $file .= " \"C$idtree\"";

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -76,7 +76,8 @@ class TreeErdController extends HfcBaseController
         }
 
         // Generate SVG file
-        $file = $this->graph_generate(NetElement::whereRaw($s));
+        $file = $this->graph_generate(NetElement::withActiveModems($field, $operator, $search)->get());
+
         if (! $file) {
             return \View::make('errors.generic', [
                 'error' => 422,
@@ -176,7 +177,7 @@ class TreeErdController extends HfcBaseController
      *
      * @author: Torsten Schmidt
      */
-    public function graph_generate($query)
+    public function graph_generate($netelements)
     {
         //
         // INIT
@@ -193,8 +194,6 @@ class TreeErdController extends HfcBaseController
 
         $n = 0;
         $p1 = '';
-
-        $netelements = NetElement::withActiveModems()->get();
 
         if (! $netelements->first()) {
             return;

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -69,7 +69,6 @@ class TreeErdController extends HfcBaseController
     {
         $operator = '=';
 
-        // prepare search query
         if ($field == 'all' || ($field == 'id' && $search == 2)) {
             $field = 'id';
             $operator = '>';

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -6,7 +6,6 @@ use Acme\php\ArrayHelper;
 use Modules\HfcReq\Entities\NetElement;
 use Modules\HfcBase\Entities\IcingaObject;
 use App\Http\Controllers\BaseViewController;
-use Modules\HfcCustomer\Entities\ModemHelper;
 
 /*
  * Tree Erd (Entity Relation Diagram) Controller
@@ -291,7 +290,7 @@ class TreeErdController extends HfcBaseController
         // TODO: Customer
         //
         if (\Module::collections()->has('HfcCustomer')) {
-            $n = 0;
+            $ModemHelper = \Modules\HfcCustomer\Entities\ModemHelper::class;
             foreach ($netelements as $netelem) {
                 $idtree = $netelem->id;
                 $id = $netelem->id;
@@ -301,7 +300,7 @@ class TreeErdController extends HfcBaseController
 
                 $state = $ModemHelper::ms_state($netelem);
                 if ($state != -1) {
-                    $color = ModemHelper::ms_state_to_color($state);
+                    $color = $ModemHelper::ms_state_to_color($state);
                     $num = $netelem->ms_num;
                     $numa = $netelem->modems_count;
                     $cri = $netelem->modems_critical_count;

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -83,7 +83,8 @@ class TreeErdController extends HfcBaseController
             }
         }
 
-        $netelements = NetElement::withActiveModems($field, $operator, $search);
+        $netelements = NetElement::withActiveModems($field, $operator, $search)
+            ->with('modemsUpstreamAvg');
 
         if (IcingaObject::db_exists()) {
             $netelements->with('icingaobject.icingahoststatus');

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -4,6 +4,7 @@ namespace Modules\HfcBase\Http\Controllers;
 
 use Acme\php\ArrayHelper;
 use Modules\HfcReq\Entities\NetElement;
+use Modules\HfcBase\Entities\IcingaObject;
 use App\Http\Controllers\BaseViewController;
 use Modules\HfcCustomer\Entities\ModemHelper;
 
@@ -75,8 +76,14 @@ class TreeErdController extends HfcBaseController
             ]);
         }
 
+        $netelements = NetElement::withActiveModems($field, $operator, $search);
+
+        if (IcingaObject::db_exists()) {
+            $netelements->with('icingaobject.icingahoststatus');
+        }
+
         // Generate SVG file
-        $file = $this->graph_generate(NetElement::withActiveModems($field, $operator, $search)->get());
+        $file = $this->graph_generate($netelements->get());
 
         if (! $file) {
             return \View::make('errors.generic', [

--- a/modules/HfcBase/Http/Controllers/TreeErdController.php
+++ b/modules/HfcBase/Http/Controllers/TreeErdController.php
@@ -67,13 +67,20 @@ class TreeErdController extends HfcBaseController
      */
     public function show($field, $search)
     {
-        $s = $field == 'all' ? 'id>2' : "$field='$search'";
+        $operator = '=';
 
-        if (! NetElement::whereRaw($s)->count()) {
-            return \View::make('errors.generic', [
-                'error' => 422,
-                'message' => trans('messages.no_Netelements'),
-            ]);
+        // prepare search query
+        if ($field == 'all' || ($field == 'id' && $search == 2)) {
+            $field = 'id';
+            $operator = '>';
+            $search = 2;
+
+            if (! NetElement::where($field, $operator, $search)->count()) {
+                return \View::make('errors.generic', [
+                    'error' => 422,
+                    'message' => trans('messages.no_Netelements'),
+                ]);
+            }
         }
 
         $netelements = NetElement::withActiveModems($field, $operator, $search);

--- a/modules/HfcBase/Http/Controllers/TreeTopographyController.php
+++ b/modules/HfcBase/Http/Controllers/TreeTopographyController.php
@@ -73,20 +73,18 @@ class TreeTopographyController extends HfcBaseController
             ]);
         }
 
+        $mpr = $this->mpr($netelements);
+        $kmls = $this->kml_file_array($netelements);
+        $tabs = TreeErdController::getTabs($field, $search);
+        $file = route('HfcBase.get_file', ['type' => 'kml', 'filename' => basename($file)]);
+
         $route_name = 'Tree';
         $view_header = 'Topography';
         $body_onload = 'init_for_map';
 
-        $tabs = TreeErdController::getTabs($field, $search);
-
-        // MPS: get all Modem Positioning Rules
-        $mpr = $this->mpr($netelements);
-
-        // NetElements: generate kml_file upload array
-        $kmls = $this->kml_file_array($netelements);
-        $file = route('HfcBase.get_file', ['type' => 'kml', 'filename' => basename($file)]);
-
-        return \View::make('HfcBase::Tree.topo', $this->compact_prep_view(compact('file', 'target', 'route_name', 'view_header', 'tabs', 'body_onload', 'field', 'search', 'mpr', 'kmls')));
+        return \View::make('HfcBase::Tree.topo', $this->compact_prep_view(compact(
+            'file', 'tabs', 'field', 'search', 'mpr', 'kmls', 'body_onload', 'view_header', 'route_name'
+        )));
     }
 
     /**
@@ -95,7 +93,7 @@ class TreeTopographyController extends HfcBaseController
      *   [ [mpr.id] => [0 => [0=>x,1=>y], 1 => [0=>x,1=>y], ..], .. ]
      * enable and see dd() for a more detailed view
      *
-     * @param trees: The Tree Objects to be displayed, without ->get() call
+     * @param trees: The Tree Objects to be displayed
      * @return array of MPS rules and geopos for all $tree objects
      *
      * @author: Torsten Schmidt
@@ -120,7 +118,6 @@ class TreeTopographyController extends HfcBaseController
             }
         }
 
-        // dd($ret);
         return $ret;
     }
 

--- a/modules/HfcBase/Http/Controllers/TreeTopographyController.php
+++ b/modules/HfcBase/Http/Controllers/TreeTopographyController.php
@@ -204,7 +204,7 @@ class TreeTopographyController extends HfcBaseController
                 $id = $netelement->id;
                 $name = $netelement->name;
                 $pos_tree = $netelement->pos;
-                $pos = $netelement->msAvgWithPos;
+                $pos = $netelement->modemsUsPwrPosAvgs;
 
                 if (isset($pos->x_avg)) {
                     $xavg = round($pos->x_avg, 4);
@@ -235,11 +235,11 @@ class TreeTopographyController extends HfcBaseController
                         <name></name>
                         <description><![CDATA[';
 
-                    $num = $netelement->ms_num;
+                    $num = $netelement->modems_online_count;
                     $numa = $netelement->modems_count;
                     $pro = $numa ? round(100 * $num / $numa, 0) : 0;
-                    $cri = $netelement->ms_cri;
-                    $avg = $netelement->msAvg;
+                    $cri = $netelement->modems_critical_count;
+                    $avg = $netelement->modemsUsPwrAvg;
                     $url = \BaseRoute::get_base_url()."/Customer/netelement_id/$id";
 
                     $file .= "Amp/Node: $name<br><br>Number All CM: $numa<br>Number Online CM: $num ($pro %)<br>Number Critical CM: $cri<br>US Level Average: $avg<br><br><a href=\"$url\" target=\"".$this->html_target.'" alt="">Show all Customers</a>';

--- a/modules/HfcBase/Http/Controllers/TreeTopographyController.php
+++ b/modules/HfcBase/Http/Controllers/TreeTopographyController.php
@@ -239,7 +239,7 @@ class TreeTopographyController extends HfcBaseController
                     $avg = $netelement->modemsUsPwrAvg;
                     $url = \BaseRoute::get_base_url()."/Customer/netelement_id/$id";
 
-                    $file .= "Amp/Node: $name<br><br>Number All CM: $numa<br>Number Online CM: $num ($pro %)<br>Number Critical CM: $cri<br>US Level Average: $avg<br><br><a href=\"$url\" target=\"".$this->html_target.'" alt="">Show all Customers</a>';
+                    $file .= "Amp/Node: $name<br><br>Number All CM: $numa<br>Number Online CM: $num ($pro %)<br>Number Critical CM: $cri<br>US Level Average: $avg<br><br><a href=\"$url\" target=\"\" alt=\"\">Show all Customers</a>";
 
                     $file .= "]]></description>
                             <styleUrl>#$icon</styleUrl>

--- a/modules/HfcBase/Http/Controllers/TreeTopographyController.php
+++ b/modules/HfcBase/Http/Controllers/TreeTopographyController.php
@@ -61,7 +61,7 @@ class TreeTopographyController extends HfcBaseController
         $netelements = NetElement::withActiveModems($field, $operator, $search)
             ->whereNotNull('pos')
             ->where('pos', '!=', ' ')
-            ->with('mprs.mprgeopos', 'modemsUpstreamAndPositionAvg')->get();
+            ->with('parent', 'mprs.mprgeopos', 'modemsUpstreamAndPositionAvg')->get();
 
         // Generate KML file
         $file = $this->kml_generate($netelements);
@@ -272,8 +272,7 @@ class TreeTopographyController extends HfcBaseController
             }
 
             $type = $netelement->type;
-            $parent = $netelement->parent ? $netelement->parent->id : null;
-            $state = $netelement->get_bsclass();
+            $parent = $netelement->parent ? $netelement->parent_id : null;
 
             if ($netelement->state == 'warning') {
                 $ystate += 1;

--- a/modules/HfcBase/Resources/views/Tree/topo.blade.php
+++ b/modules/HfcBase/Resources/views/Tree/topo.blade.php
@@ -47,6 +47,7 @@
 				@endif
 			</div>
 		</div>
+		@if (! isset($field))
 		<ul class="nav nav-pills align-self-end ml-auto mr-5">
 			<?php
 				$par = array_merge(Route::getCurrentRoute()->parameters(), \Request::all());
@@ -58,6 +59,7 @@
 				}
 			?>
 		</ul>
+		@endif
 	</div>
 	<div class="container-fluid m-t-20 m-b-20">
 		<div class="col-md-12 d-flex" id="map" style="height:75vh"></div>

--- a/modules/HfcCustomer/Console/ClustersCommand.php
+++ b/modules/HfcCustomer/Console/ClustersCommand.php
@@ -43,8 +43,8 @@ class ClustersCommand extends Command
     {
         $ret = 'OK';
         $perf = '';
-        foreach (NetElement::where('id', '>', '2')->get() as $element) {
-            $state = ModemHelper::ms_state($element->id);
+        foreach (NetElement::withActiveModems()->get() as $netelement) {
+            $state = ModemHelper::ms_state($netelement);
             if ($state == -1) {
                 continue;
             }
@@ -55,10 +55,10 @@ class ClustersCommand extends Command
                 $ret = $state;
             }
 
-            $num = ModemHelper::ms_num($element->id);
-            $numa = ModemHelper::ms_num_all($element->id);
-            $cm_cri = ModemHelper::ms_cri($element->id);
-            $avg = ModemHelper::ms_avg($element->id);
+            $num = $netelement->ms_num;
+            $numa = $netelement->modems_count;
+            $cm_cri = $netelement->ms_cri;
+            $avg = $netelement->msAvg;
             $warn_per = ModemHelper::$avg_warning_percentage / 100 * $numa;
             $crit_per = ModemHelper::$avg_critical_percentage / 100 * $numa;
             $warn_us = ModemHelper::$avg_warning_us;

--- a/modules/HfcCustomer/Entities/ModemHelper.php
+++ b/modules/HfcCustomer/Entities/ModemHelper.php
@@ -59,8 +59,8 @@ class ModemHelper extends \BaseModel
             return -1;
         }
 
-        $onl = $netelem->ms_num;
-        $avg = $netelem->msAvg;
+        $onl = $netelem->modems_online_count;
+        $avg = $netelem->modemsUsPwrAvg;
 
         if ($onl / $all * 100 < self::$avg_critical_percentage || $avg > self::$avg_critical_us) {
             return 'CRITICAL';

--- a/modules/HfcCustomer/Entities/ModemHelper.php
+++ b/modules/HfcCustomer/Entities/ModemHelper.php
@@ -2,8 +2,6 @@
 
 namespace Modules\HfcCustomer\Entities;
 
-use Modules\ProvBase\Entities\Modem;
-
 class ModemHelper extends \BaseModel
 {
     // TODO: use should be from a global config api
@@ -13,28 +11,6 @@ class ModemHelper extends \BaseModel
     public static $avg_warning_percentage = 70;
     public static $avg_critical_us = 52;
     public static $avg_warning_us = 45;
-
-    public static function ms_num($s)
-    {
-        return Modem::where('netelement_id', $s)->where('us_pwr', '>', '0')->count();
-    }
-
-    public static function ms_num_all($s)
-    {
-        return Modem::where('netelement_id', $s)->count();
-    }
-
-    public static function ms_avg($s)
-    {
-        return round(Modem::where('netelement_id', $s)->where('us_pwr', '>', '0')->avg('us_pwr'), 1);
-    }
-
-    public static function ms_cri($s)
-    {
-        $c = self::$single_critical_us;
-
-        return Modem::where('netelement_id', $s)->where('us_pwr', '>', $c)->count();
-    }
 
     public static function _ms_state($onl, $all, $avg)
     {
@@ -85,15 +61,5 @@ class ModemHelper extends \BaseModel
         }
 
         return -1;
-    }
-
-    public static function ms_avg_pos($s)
-    {
-        $q = Modem::where('netelement_id', $s)
-            ->where('us_pwr', '>', '0')
-            ->where('x', '<>', '0')
-            ->where('y', '<>', '0');
-
-        return ['x' => round($q->avg('x'), 4), 'y' => round($q->avg('y'), 4)];
     }
 }

--- a/modules/HfcCustomer/Entities/ModemHelper.php
+++ b/modules/HfcCustomer/Entities/ModemHelper.php
@@ -52,15 +52,15 @@ class ModemHelper extends \BaseModel
         return 'OK';
     }
 
-    public static function ms_state($s)
+    public static function ms_state($netelem)
     {
-        $all = self::ms_num_all($s);
+        $all = $netelem->modems_count;
         if ($all == 0) {
             return -1;
         }
 
-        $onl = self::ms_num($s);
-        $avg = self::ms_avg($s);
+        $onl = $netelem->ms_num;
+        $avg = $netelem->msAvg;
 
         if ($onl / $all * 100 < self::$avg_critical_percentage || $avg > self::$avg_critical_us) {
             return 'CRITICAL';

--- a/modules/HfcCustomer/Http/Controllers/CustomerTopoController.php
+++ b/modules/HfcCustomer/Http/Controllers/CustomerTopoController.php
@@ -30,6 +30,8 @@ use Modules\HfcReq\Http\Controllers\NetElementController;
  */
 class CustomerTopoController extends NetElementController
 {
+    protected $html_target = '';
+
     /*
      * Local tmp folder required for generating the images
      * (relative to /storage/app)

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -6,7 +6,6 @@ use Auth;
 use Cache;
 use Session;
 use Modules\HfcBase\Entities\IcingaObject;
-use Modules\HfcCustomer\Entities\ModemHelper;
 
 class NetElement extends \BaseModel
 {
@@ -142,16 +141,17 @@ class NetElement extends \BaseModel
      */
     public function scopeWithActiveModems($query, $field = 'id', $operator = '>', $id = 2)
     {
+        $ModemHelper = \Modules\HfcCustomer\Entities\ModemHelper::class;
+
         return $query->where($field, $operator, $id)
-        ->with('netelementtype', 'parent')
         ->orderBy('pos')
         ->withCount([
             'modems',
             'modems as modems_online_count' => function ($query) {
                 return $query->where('us_pwr', '>', '0');
             },
-            'modems as modems_critical_count' => function ($query) {
-                $query->where('us_pwr', '>', ModemHelper::$single_critical_us);
+            'modems as modems_critical_count' => function ($query) use ($ModemHelper) {
+                $query->where('us_pwr', '>', $ModemHelper::$single_critical_us);
             },
         ]);
     }

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -147,10 +147,10 @@ class NetElement extends \BaseModel
         ->orderBy('pos')
         ->withCount([
             'modems',
-            'modems as ms_num' => function ($query) {
+            'modems as modems_online_count' => function ($query) {
                 return $query->where('us_pwr', '>', '0');
             },
-            'modems as ms_cri' => function ($query) {
+            'modems as modems_critical_count' => function ($query) {
                 $query->where('us_pwr', '>', ModemHelper::$single_critical_us);
             },
         ]);
@@ -215,7 +215,7 @@ class NetElement extends \BaseModel
     public function modemsUpstreamAvg()
     {
         return $this->modems()
-            ->selectRaw('AVG(us_pwr) as ms_avg, netelement_id')
+            ->selectRaw('AVG(us_pwr) as us_pwr_avg, netelement_id')
             ->groupBy('netelement_id');
     }
 
@@ -225,7 +225,7 @@ class NetElement extends \BaseModel
             ->where('us_pwr', '>', '0')
             ->where('x', '<>', '0')
             ->where('y', '<>', '0')
-            ->selectRaw('AVG(us_pwr) as ms_avg, AVG(x) as x_avg, AVG(y) as y_avg, netelement_id')
+            ->selectRaw('AVG(us_pwr) as us_pwr_avg, AVG(x) as x_avg, AVG(y) as y_avg, netelement_id')
             ->groupBy('netelement_id');
     }
 
@@ -234,17 +234,17 @@ class NetElement extends \BaseModel
      *
      * @return int
      */
-    public function getMsAvgAttribute()
+    public function getModemsUsPwrAvgAttribute()
     {
         if (array_key_exists('modemsUpstreamAndPositionAvg', $this->relations)) {
-            return round($this->getRelation('modemsUpstreamAndPositionAvg')->first()->ms_avg, 1);
+            return round($this->getRelation('modemsUpstreamAndPositionAvg')->first()->us_pwr_avg, 1);
         }
 
         if (! array_key_exists('modemsUpstreamAvg', $this->relations)) {
             $this->load('modemsUpstreamAvg');
         }
 
-        return round($this->getRelation('modemsUpstreamAvg')->first()->ms_avg, 1);
+        return round($this->getRelation('modemsUpstreamAvg')->first()->us_pwr_avg, 1);
     }
 
     /**
@@ -253,7 +253,7 @@ class NetElement extends \BaseModel
      *
      * @return int
      */
-    public function getMsAvgWithPosAttribute()
+    public function getModemsUsPwrPosAvgsAttribute()
     {
         if (! array_key_exists('modemsUpstreamAndPositionAvg', $this->relations)) {
             $this->load('modemsUpstreamAndPositionAvg');

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -104,7 +104,7 @@ class NetElement extends \BaseModel
             return 'info';
         }
 
-        if (! IcingaObject::db_exists()) {
+        if (! array_key_exists('icingaobject', $this->relations) && ! IcingaObject::db_exists()) {
             return 'warning';
         }
 

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -140,9 +140,9 @@ class NetElement extends \BaseModel
      * @param Illuminate\Database\Query\Builder $query
      * @return Illuminate\Database\Query\Builder
      */
-    public function scopeWithActiveModems($query)
+    public function scopeWithActiveModems($query, $field = 'id', $operator = '>', $id = 2)
     {
-        return $query->where('id', '>', '2')
+        return $query->where($field, $operator, $id)
         ->with('netelementtype', 'parent', 'ms_avg')
         ->orderBy('pos')
         ->withCount([

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -208,6 +208,32 @@ class NetElement extends \BaseModel
     }
 
     /**
+     * Get the average upstream power of connected modems
+     *
+     * @return HasMany Filtered and aggregated modem Relationship
+     */
+    public function ms_avg()
+    {
+        return $this->modems()
+            ->selectRaw('AVG(us_pwr) as ms_avg, netelement_id')
+            ->groupBy('netelement_id');
+    }
+
+    /**
+     * Laravel Magic Method to access average upstream power of connected modems
+     *
+     * @return int
+     */
+    public function getMsAvgAttribute()
+    {
+        if (! array_key_exists('ms_avg', $this->relations)) {
+            $this->load('ms_avg');
+        }
+
+        return round($this->getRelation('ms_avg')->first()->ms_avg, 1);
+    }
+
+    /**
      * Get first parent of type NetGw
      *
      * @return object NetElement 	(or NULL if there is no parent NetGw)

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -6,6 +6,7 @@ use Auth;
 use Cache;
 use Session;
 use Modules\HfcBase\Entities\IcingaObject;
+use Modules\HfcCustomer\Entities\ModemHelper;
 
 class NetElement extends \BaseModel
 {
@@ -127,6 +128,32 @@ class NetElement extends \BaseModel
     public function view_belongs_to()
     {
         return $this->netelementtype;
+    }
+
+    /**
+     * Scopes
+     */
+
+    /**
+     * Scope to receive active connected Modems with several important counts.
+     *
+     * @param Illuminate\Database\Query\Builder $query
+     * @return Illuminate\Database\Query\Builder
+     */
+    public function scopeWithActiveModems($query)
+    {
+        return $query->where('id', '>', '2')
+        ->with('netelementtype', 'parent', 'ms_avg')
+        ->orderBy('pos')
+        ->withCount([
+            'modems',
+            'modems as ms_num' => function ($query) {
+                return $query->where('us_pwr', '>', '0');
+            },
+            'modems as ms_cri' => function ($query) {
+                $query->where('us_pwr', '>', ModemHelper::$single_critical_us);
+            },
+        ]);
     }
 
     /**

--- a/modules/ProvBase/Database/Migrations/2020_01_23_111514_set_index_for_netelements_in_modem_table.php
+++ b/modules/ProvBase/Database/Migrations/2020_01_23_111514_set_index_for_netelements_in_modem_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+class SetIndexForNetelementsInModemTable extends BaseMigration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('modem', function (Blueprint $table) {
+            $table->index('netelement_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('modem', function (Blueprint $table) {
+            $table->dropIndex(['netelement_id']);
+        });
+    }
+}

--- a/modules/ProvBase/Http/Controllers/ContractController.php
+++ b/modules/ProvBase/Http/Controllers/ContractController.php
@@ -145,7 +145,7 @@ class ContractController extends \BaseController
                 ['form_type' => 'select', 'name' => 'next_qos_id', 'description' => 'QoS next month', 'value' => $model->html_list($qoss, 'name', true)],
             ];
 
-            if ($model->external_voip_enabled) {
+            if (\Module::collections()->has('ProvVoipEnvia')) {
                 $purchase_tariffs = PhoneTariff::get_purchase_tariffs();
                 $sales_tariffs = PhoneTariff::get_sale_tariffs();
 

--- a/resources/views/bootstrap/sidebar.blade.php
+++ b/resources/views/bootstrap/sidebar.blade.php
@@ -73,7 +73,7 @@
               </a>
             <ul class="sub-menu d-block" style="list-style-position: inside;">
               {{-- Network-Clusters are Cached for 5 minutes --}}
-              @foreach ($network->get_all_cluster_to_net() as $cluster)
+              @foreach ($network->clusters as $cluster)
                 <li id="cluster_{{$cluster->id}}" class="has-sub" data-sidebar="level3">
                   <a href="{{ route('TreeErd.show', ['field' => 'cluster', 'search' => $cluster->id]) }}" style="width: 100%;text-overflow: ellipsis;overflow: hidden;white-space: nowrap;">
                     <i class="fa fa-circle-thin text-info"></i>


### PR DESCRIPTION
It annoyed me that the ERD pages, especially the "All Nets", took so long to load.

On inspection I got over 970 Queries on TreeErd-View and 1600+ Queries for Topography view for "All Nets" per page load on a system with 200 Netelements.

This PR fixes this and reduces the queries to 6 in ERD view and 8 in Topography and therefore also the time for a page load significantly.

To get Stable this is possibly a Feature for 2.6.x?