### PR TITLE
small bugfixes

### DIFF
--- a/app/Ability.php
+++ b/app/Ability.php
@@ -8,4 +8,11 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 class Ability extends Eloquent
 {
     use IsAbility;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
 }

--- a/config/base.php
+++ b/config/base.php
@@ -8,7 +8,7 @@ return[
             'icon' => 'fa-book',
             'class' => App\GlobalConfig::class,
         ],
-        'Logging' => [
+        'Log' => [
             'link' => 'GuiLog.index',
             'icon' => 'fa-history',
             'class' => App\GuiLog::class,

--- a/modules/HfcReq/Entities/NetElement.php
+++ b/modules/HfcReq/Entities/NetElement.php
@@ -224,6 +224,7 @@ class NetElement extends \BaseModel
     public function modemsUpstreamAvg()
     {
         return $this->modems()
+            ->where('us_pwr', '>', '0')
             ->selectRaw('AVG(us_pwr) as us_pwr_avg, netelement_id')
             ->groupBy('netelement_id');
     }

--- a/resources/lang/de/view.php
+++ b/resources/lang/de/view.php
@@ -44,7 +44,7 @@ return [
     'Menu_MainMenu'             => 'Hauptmenü',
     'Menu_Node'                 => 'Übergabepunkte',
     'Menu_Config Page'          => 'Systemkonfiguration',
-    'Menu_Logging'              => 'Logs',
+    'Menu_Log'                  => 'Log',
     'Menu_Product List'         => 'Produktangebot',
     'Menu_SEPA Accounts'        => 'SEPA-Konten',
     'Menu_Settlement Run'       => 'Abrechnungslauf',

--- a/resources/lang/en/view.php
+++ b/resources/lang/en/view.php
@@ -44,7 +44,7 @@ return [
     'Menu_MainMenu'             => 'Main Menu',
     'Menu_Node'                 => 'Nodes',
     'Menu_Config Page'          => 'Global Config Page',
-    'Menu_Logging'              => 'Logging',
+    'Menu_Log'                  => 'Log',
     'Menu_Product List'         => 'Product List',
     'Menu_SEPA Accounts'        => 'SEPA Accounts',
     'Menu_Settlement Run'       => 'Settlement Run',

--- a/resources/views/bootstrap/sidebar.blade.php
+++ b/resources/views/bootstrap/sidebar.blade.php
@@ -37,8 +37,8 @@
             </div>
           <ul class="sub-menu">
           @foreach ($typearray['submenu'] as $type => $valuearray)
-          <li id="{{ Str::slug($type,'_') }}">
-            <a href="{{route($valuearray['link'])}}" style="overflow: hidden; white-space: nowrap;">
+          <li id="menu-{{ Str::slug($type,'_') }}">
+            <a href="{{ route($valuearray['link']) }}" style="overflow: hidden; white-space: nowrap;">
               <i class="fa fa-fw {{ $valuearray['icon'] }}"></i>
               <span>{{ $type }}</span>
             </a>


### PR DESCRIPTION
* As __Ability__ derives from base __Eloquent Model__ a _fillable_ or _guarded_ property must be set to avoid a _mass assignment exception_
* When NMS Prime was set to English the id __logging__ was set twice and caused misbehaviour of the logging tab in the edit pages
* Average Upstream calculation included offline modems -> now only modems with upstream > 0 are considered
