### PR TITLE
Bugfix/small fixes par

### DIFF
--- a/modules/Ccc/Database/Migrations/2020_03_18_000100_update_CccAuthuserMakeNameFieldsNullable.php
+++ b/modules/Ccc/Database/Migrations/2020_03_18_000100_update_CccAuthuserMakeNameFieldsNullable.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * Seems that 2020_01_13_110520_set_empty_strings_to_null_ccc.php did not affect table cccauthuser (due to missing/wrong connection?)
+ * We fix the problem manually and explicitely here…
+ *
+ * @author Patrick Reichel
+ */
+class UpdateCccAuthuserMakeNameFieldsNullable extends BaseMigration
+{
+    protected $tablename = 'cccauthuser';
+    protected $connection = 'mysql-ccc';
+
+    // the rows to be nullable (firstname/lastname in contract can be null if type is institutional)
+    protected $cols = [
+        'first_name',
+        'last_name',
+    ];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection($this->connection)->table($this->tablename, function (Blueprint $table) {
+            foreach ($this->cols as $col) {
+                $table->string($col)->nullable()->change();
+            }
+        });
+        foreach ($this->cols as $col) {
+            DB::connection($this->connection)->update("UPDATE $this->tablename SET $col=NULL WHERE $col=''");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        foreach ($this->cols as $col) {
+            DB::connection($this->connection)->update("UPDATE $this->tablename SET $col='' WHERE $col IS NULL");
+        }
+        Schema::connection($this->connection)->table($this->tablename, function (Blueprint $table) {
+            foreach ($this->cols as $col) {
+                $table->string($col)->change();
+            }
+        });
+    }
+}

--- a/modules/Ccc/Http/Controllers/CccUserController.php
+++ b/modules/Ccc/Http/Controllers/CccUserController.php
@@ -155,7 +155,7 @@ class CccUserController extends \BaseController
         // }
 
         if ($msg_key) {
-            $msg = trans('messages.conninfo.error').trans("messages.conninfo.$msg_key", $msg_var ? ['var' => $msg_var] : null);
+            $msg = trans('messages.conninfo.error').trans("messages.conninfo.$msg_key", $msg_var ? ['var' => $msg_var] : []);
 
             Log::error($msg);
             \Session::flash('download_error', $msg);


### PR DESCRIPTION
PR fixes another problem caused by setting empty strings to null: NMS crashes on creating connection info PDF for institutional contracts with empty lastname/firstname.

Hopefully I did not introduce another bug (caused by NULL) – the reviewer should think about side effects, too

Maybe we should add some more functionality:
- add field for company in cccauthuser
- add method to generate user string for use in logging and GUI
- make last_name and first_name required on MVC for NMS users